### PR TITLE
fix issue with pulsevol not running replace with existing changevolum…

### DIFF
--- a/config/rc.xml
+++ b/config/rc.xml
@@ -715,17 +715,17 @@
     </keybind>
     <keybind key="XF86AudioRaiseVolume">
       <action name="Execute">
-        <command>pulsevol --up</command>
+        <command>~/.config/openbox/scripts/changevolume up</command>
       </action>
     </keybind>
     <keybind key="XF86AudioLowerVolume">
       <action name="Execute">
-        <command>pulsevol --down</command>
+        <command>~/.config/openbox/scripts/changevolume down</command>
       </action>
     </keybind>
     <keybind key="XF86AudioMute">
       <action name="Execute">
-        <command>pulsevol --mute</command>
+        <command>~/.config/openbox/scripts/changevolume mute</command>
       </action>
     </keybind>
     <!-- Screenshot Keybindings -->


### PR DESCRIPTION
Changing volume had 2 different flows.

Super + <key> shortcuts work fine out of the box.

However using media keys on the keyboard keeps showing a dialog saying
'Child process 'pulsevol' not running' or something like that.

In that commit i just aligned the media key flow to behave in the same manner as 'Super' shortcuts.